### PR TITLE
Fix exception when toot contains unicode symbols

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -163,7 +163,7 @@ while 1:
             print("Error posting tweet: '{tweet}' (length {length}). {error}"\
                 .format(tweet=tweet, length=len(tweet), error=ex))
             exit(1)
-        print("Tweeting: {}".format(tweet))
+        print("Tweeting: {}".format(tweet).encode('utf-8'))
 
     # Sleep and show next update timer
     sleep_seconds = config.interval_minutes * 60


### PR DESCRIPTION
`bot.py` crashed with:

```Traceback (most recent call last):
  File "bot.py", line 166, in <module>
    print("Tweeting: {}".format(tweet))
UnicodeEncodeError: 'ascii' codec can't encode character '\u2026' in position 112: ordinal not in range(128)```