### PR TITLE
add picture tweeting capabilities.

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -1,6 +1,7 @@
 {
     "link_to_mastodon": false,
     "tags_to_append": 2,
+    "post_media": true,
     "mastodon": {
         "api_base_url": "https://mstdn.io",
         "user_base_url": "mstdn.io/@bitkeks/",


### PR DESCRIPTION
when tooting with attached media (i.e: pictures), these were not
being processed to the mirror tweet posted. This commit introduces
the ability to post attached media from the toot into tweets.

Fixes #4

Signed-off-by: Simental Magana, Marcos <mrkzmrkz@gmail.com>